### PR TITLE
refactor(ci): switch to setup-gradle action

### DIFF
--- a/.github/workflows/codeql-java.yml
+++ b/.github/workflows/codeql-java.yml
@@ -47,13 +47,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
         with:
           gradle-version: wrapper
       - name: CodeQL Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
-        with:
-          arguments: compileJava
+        id: codeql_build
+        run: |
+          ./gradlew compileJava
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
         id: code_analyzer

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -39,15 +39,17 @@ jobs:
         with:
           java-version: 21
           distribution: "temurin"
-      - name: Execute Gradle Check
-        # actually doesn't do anything other than assert than things compile
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
-        id: gradle
+      - name: Setup Gradle
+        id: setup_gradle
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
         with:
           gradle-version: wrapper
-          arguments: check
+      - name: Gradle
+        id: gradle
         env:
           JDK_JAVA_OPTIONS: -Dpolyglot.js.nashorn-compat=true -Dpolyglot.engine.WarnInterpreterOnly=false
+        run: |
+          ./gradlew check
       - name: Build Result
         if: |
           (success() || failure()) &&

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
-      - name: Gradle Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
         id: gradle
         with:
           dependency-graph: generate-and-submit

--- a/.github/workflows/update-quarkus.yml
+++ b/.github/workflows/update-quarkus.yml
@@ -34,11 +34,14 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Gradle Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
         id: gradle
         with:
           gradle-version: wrapper
-          arguments: quarkusUpdate
+      - name: Build
+        id: build
+        run: |
+          ./gradlew quarkusUpdate
       - name: Quarkus Release
         id: latestQuarkus
         env:


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Release notes for gradle/gradle-build-action@v3.0.0 says it's been deprecated in favour of gradle/actions/setup-gradle@v3.0.0


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- switch to using gradle/actions/setup-gradle pinned to a hash
- remove use of 'arguments' in favour of a subsequent step executes gradle
<!-- SQUASH_MERGE_END -->

