### PR TITLE
refactor: use response predicate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -115,7 +115,7 @@ build style="jar":
 
 # ./gradlew quarkusRun
 @run: check_tesla_env
-  ./gradlew -Dorg.gradle.console=plain build quarkusRun
+  ./gradlew -Dorg.gradle.daemon=false -Dorg.gradle.console=plain quarkusRun
 
 [private]
 [no-cd]

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation 'io.quarkus:quarkus-scheduler'
   implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
   implementation 'io.quarkus:quarkus-arc'
-  implementation 'io.quarkus:quarkus-qute'
+  implementation 'io.quarkus:quarkus-rest-jackson'
   implementation 'io.smallrye.reactive:smallrye-mutiny-vertx-web-client'
   implementation 'org.slf4j:slf4j-api'
   implementation 'org.apache.commons:commons-text'

--- a/src/main/java/io/github/qe/powerwall/RestClient.java
+++ b/src/main/java/io/github/qe/powerwall/RestClient.java
@@ -1,16 +1,23 @@
 package io.github.qe.powerwall;
 
-import io.quarkus.qute.Qute;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -20,16 +27,6 @@ public class RestClient {
 
   private final WebClient client;
   private static final Duration MAX_WAIT = Duration.ofSeconds(30);
-  private static final String loginJson =
-      """
-      {
-        "clientInfo": {
-          "timezone" : "UTC"
-        },
-        "email": "{email}",
-        "password": "{password}",
-        "username": "customer"
-      }""";
 
   @ConfigProperty(name = "powerwall.gateway.pw")
   private String password;
@@ -40,6 +37,9 @@ public class RestClient {
   @ConfigProperty(name = "powerwall.gateway.server")
   @Getter
   private String gatewayAddress;
+
+  private static final ResponsePredicate JSON_OR_TEXT =
+      ResponsePredicate.contentType(List.of("application/json", "text/plain"));
 
   private String token;
   private boolean loggedIn = false;
@@ -57,19 +57,16 @@ public class RestClient {
 
   public boolean login(boolean forcedLogging) {
     logging(forcedLogging, "Login to {}", gatewayAddress);
-    Buffer buffer =
-        Buffer.buffer(
-            Qute.fmt(loginJson).data("email", email).data("password", password).render(), "UTF-8");
+    LoginObject login = LoginObject.builder().email(email).password(password).build();
+    JsonObject jsonPayload = JsonObject.mapFrom(login);
     token =
         client
             .postAbs(uri("login/Basic"))
-            .sendBuffer(buffer)
+            .expect(ResponsePredicate.SC_SUCCESS)
+            .expect(JSON_OR_TEXT) // this is kinda weird should be .expect(ResponsePredicate.JSON)
+            .sendJsonObject(jsonPayload)
             .onItem()
-            .transform(
-                r -> {
-                  assertStatus(r.statusCode(), true);
-                  return r.bodyAsJsonObject().getString("token");
-                })
+            .transform(r -> r.bodyAsJsonObject().getString("token"))
             .await()
             .atMost(MAX_WAIT);
     loggedIn = token != null;
@@ -106,27 +103,34 @@ public class RestClient {
     return String.format("%s/api/%s", gatewayAddress, uri);
   }
 
-  private void assertStatus(int httpCode, boolean failOn400) {
-    switch (httpCode) {
-      case 403, 401 -> {
-        loggedIn = false;
-        if (failOn400) {
-          throw new IllegalStateException("Forbidden " + httpCode);
-        }
-      }
-      case 200 -> {}
-      default -> {
-        loggedIn = false;
-        throw new IllegalStateException("Unexpected Status code " + httpCode);
-      }
-    }
-  }
-
   private void logging(boolean forced, String msg, Object... args) {
     if (forced) {
       log.info(msg, args);
     } else {
       log.debug(msg, args);
     }
+  }
+
+  /*
+  {
+    "clientInfo": {
+      "timezone" : "UTC"
+    },
+    "email": "{email}",
+    "password": "{password}",
+    "username": "customer"
+  }
+   */
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(builderClassName = "Builder")
+  @Getter
+  @JsonNaming(PropertyNamingStrategies.LowerCamelCaseStrategy.class)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private static class LoginObject {
+    @Setter private String email;
+    @Setter private String password;
+    private final String username = "customer";
+    private final Map<String, String> clientInfo = Map.of("timezone", "UTC");
   }
 }

--- a/src/main/java/io/github/qe/powerwall/RestClient.java
+++ b/src/main/java/io/github/qe/powerwall/RestClient.java
@@ -5,6 +5,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.WebClient;
+import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
@@ -89,14 +90,12 @@ public class RestClient {
     Map<String, Object> result =
         client
             .getAbs(uri(api))
+            .expect(ResponsePredicate.SC_SUCCESS)
+            .expect(ResponsePredicate.JSON)
             .putHeader("Authorization", "Bearer " + token)
             .send()
             .onItem()
-            .transform(
-                r -> {
-                  assertStatus(r.statusCode(), false);
-                  return r.bodyAsJsonObject().getMap();
-                })
+            .transform(r -> r.bodyAsJsonObject().getMap())
             .await()
             .atMost(MAX_WAIT);
     logging(forcedLogging, "Scraped {}", api);

--- a/src/test/java/io/github/qe/powerwall/ForbiddenTest.java
+++ b/src/test/java/io/github/qe/powerwall/ForbiddenTest.java
@@ -1,12 +1,14 @@
 package io.github.qe.powerwall;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.qe.powerwall.Profiles.Forbidden;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import jakarta.inject.Inject;
+import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -27,11 +29,16 @@ public class ForbiddenTest {
   }
 
   @Test
-  void testClient() {
-    assertAll(
-        () -> assertThrows(IllegalStateException.class, () -> client.login(true)),
-        () ->
-            assertThrows(
-                IllegalStateException.class, () -> client.get("system_status/soe", false)));
+  void testClientLogin() {
+    CompletionException e1 = assertThrows(CompletionException.class, () -> client.login(true));
+    assertInstanceOf(NoStackTraceThrowable.class, e1.getCause());
+  }
+
+  @Test
+  void testClientGet() {
+    CompletionException e =
+        assertThrows(CompletionException.class, () -> client.get("system_status/soe", false));
+    assertInstanceOf(NoStackTraceThrowable.class, e.getCause());
+    //    assertThrows(IllegalStateException.class, () -> client.get("system_status/soe", false));
   }
 }

--- a/src/test/java/io/github/qe/powerwall/NoTokenTest.java
+++ b/src/test/java/io/github/qe/powerwall/NoTokenTest.java
@@ -1,12 +1,14 @@
 package io.github.qe.powerwall;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.qe.powerwall.Profiles.NoToken;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import jakarta.inject.Inject;
-import java.util.Map;
+import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -28,7 +30,8 @@ public class NoTokenTest {
 
   @Test
   void testClient() {
-    Map<String, Object> result = client.get("system_status/soe", false);
-    assertEquals(0, result.size());
+    CompletionException e =
+        assertThrows(CompletionException.class, () -> client.get("system_status/soe", false));
+    assertInstanceOf(NoStackTraceThrowable.class, e.getCause());
   }
 }

--- a/src/test/java/io/github/qe/powerwall/NotFoundTest.java
+++ b/src/test/java/io/github/qe/powerwall/NotFoundTest.java
@@ -1,11 +1,14 @@
 package io.github.qe.powerwall;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.qe.powerwall.Profiles.NotFound;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import jakarta.inject.Inject;
+import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -27,6 +30,9 @@ public class NotFoundTest {
 
   @Test
   void testClient() {
-    assertThrows(IllegalStateException.class, () -> client.get("system_status/soe", false));
+    CompletionException e =
+        assertThrows(CompletionException.class, () -> client.get("system_status/soe", false));
+    assertInstanceOf(NoStackTraceThrowable.class, e.getCause());
+    //    assertThrows(IllegalStateException.class, () -> client.get("system_status/soe", false));
   }
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
There's no reasons to have the assertStatus method once we've found out about ResponsePredicate

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove assertStatus in favour of ResponsePredicate
- accessing a real powerwall shows we have to cope with text/plain as a content type (even though the data is JSON).
- switch fully to jackson rather than Qute.
- make sure that 'just run' does not use gradle daemon
<!-- SQUASH_MERGE_END -->

## Notes

vscode rest gives us a content type application/json, but curl does not which is very curious, but life is kind of too short to find the correct incantation.

```bash
bsh ❯ curl -k -i --request POST \
  --url https://powerwall/api/login/Basic \
  --header 'content-type: application/json' \
  --header 'Accept: application/json' \
  --header 'user-agent: vscode-restclient' \
  --data '{"clientInfo": {"timezone" : "UTC"},"email": "XXXX","password": "YYYYYY","username": "customer"}'
HTTP/2 200
cache-control: no-cache, no-store
set-cookie: ...
set-cookie: ...
content-type: text/plain; charset=utf-8
content-length: 269
date: Fri, 17 May 2024 19:07:22 GMT

{"email":"XXXX","firstname":"Tesla","lastname":"Energy","roles":["Home_Owner"],"token":"tokeny-token","provider":"Basic","loginTime":"2024-05-17T20:07:22.404594925+01:00"}
```
