### PR TITLE
refactor: switch back to qute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation 'io.quarkus:quarkus-scheduler'
   implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
   implementation 'io.quarkus:quarkus-arc'
-  implementation 'io.quarkus:quarkus-rest-jackson'
+  implementation 'io.quarkus:quarkus-qute'
   implementation 'io.smallrye.reactive:smallrye-mutiny-vertx-web-client'
   implementation 'org.slf4j:slf4j-api'
   implementation 'org.apache.commons:commons-text'


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Native build does not work with quarkus-jackson; suspect it is to do with the rendering of the
LoginObject into a string when posting data.

You get a 401 back from the powerwall because the JSON isn't well formed or something.
Worth investigating but nicer to have something that _could_ be a native binary than not.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- revert back to using Qute rather than jackson for login object
<!-- SQUASH_MERGE_END -->

