### PR TITLE
ci: add native build to docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,6 +2,7 @@ name: docker-image
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   docker-build-image:
@@ -33,6 +34,36 @@ jobs:
           registry_push: true
           dockerfile: ./src/main/docker/Dockerfile.cgr
           image_platforms: linux/amd64,linux/arm64/v8
+          ghcr_image_name: ghcr.io/${{ github.repository }}
+          ghcr_user: ${{ github.repository_owner }}
+          ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-build-native:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          java-version: 21
+          distribution: "temurin"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
+        id: gradle
+      - name: Build
+        id: build
+        run: |
+          ./gradlew build -Dquarkus.package.jar.enabled=false -Dquarkus.native.enabled=true -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker
+      - name: docker-build-push
+        uses: quotidian-ennui/actions-olio/docker-image-builder@main
+        with:
+          registry_push: true
+          dockerfile: ./src/main/docker/Dockerfile.native-micro
+          image_platforms: linux/amd64
+          image_tag_suffix: "-native"
           ghcr_image_name: ghcr.io/${{ github.repository }}
           ghcr_user: ${{ github.repository_owner }}
           ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 set positional-arguments := true
 DOCKER_CONTAINER:= "powerwall-export"
 DOCKERFILE:= justfile_directory() / "src/main/docker/Dockerfile.jvm"
-DOCKERFILE_NATIVE:= justfile_directory() / "src/main/docker/Dockerfile.native"
+DOCKERFILE_NATIVE:= justfile_directory() / "src/main/docker/Dockerfile.native-micro"
 DOCKERFILE_CGR:= justfile_directory() / "src/main/docker/Dockerfile.cgr"
 
 DOCKER_IMAGE_TAG := `whoami` / DOCKER_CONTAINER + ":latest"
@@ -116,7 +116,7 @@ release push="localonly":
 # Cleanup
 @clean:
   rm -rf node_modules build bin
-  -docker images | grep -e "^<none>" -e "{{ DOCKER_CONTAINER }}" | awk '{print $3}' | xargs -r docker rmi
+  -docker images | grep -e "<none>" -e "{{ DOCKER_CONTAINER }}" | awk '{print $3}' | xargs -r docker rmi
 
 # Do a build perhaps in the style of jar|uber|native
 build style="jar":

--- a/src/main/docker/Dockerfile.native-cgr
+++ b/src/main/docker/Dockerfile.native-cgr
@@ -1,0 +1,9 @@
+# gradle build -Dquarkus.package.jar.enabled=false \
+#            -Dquarkus.native.enabled=true -Dquarkus.native.container-build=true \
+#            -Dquarkus.native.container-runtime=docker
+FROM cgr.dev/chainguard/graalvm-native:latest
+
+WORKDIR /work
+EXPOSE 8080
+COPY --chown=nonroot.nonroot build/*-runner /work/application
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
It's now worth publishing a native image (amd64) docker build

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add native build to docker-image.yml using native-micro
- add chainguard native dockerfile
<!-- SQUASH_MERGE_END -->

